### PR TITLE
Fix assert with mz_zip_writer_add_mem* w/MZ_DEFAULT_COMPRESSION

### DIFF
--- a/miniz_zip.c
+++ b/miniz_zip.c
@@ -3131,14 +3131,15 @@ mz_bool mz_zip_writer_add_mem_ex_v2(mz_zip_archive *pZip, const char *pArchive_n
     mz_uint8 extra_data[MZ_ZIP64_MAX_CENTRAL_EXTRA_FIELD_SIZE];
     mz_uint16 bit_flags = 0;
 
+    if ((int)level_and_flags < 0)
+        level_and_flags = MZ_DEFAULT_LEVEL;
+
     if (uncomp_size || (buf_size && !(level_and_flags & MZ_ZIP_FLAG_COMPRESSED_DATA)))
         bit_flags |= MZ_ZIP_LDH_BIT_FLAG_HAS_LOCATOR;
 
     if (!(level_and_flags & MZ_ZIP_FLAG_ASCII_FILENAME))
         bit_flags |= MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_UTF8;
 
-    if ((int)level_and_flags < 0)
-        level_and_flags = MZ_DEFAULT_LEVEL;
     level = level_and_flags & 0xF;
     store_data_uncompressed = ((!level) || (level_and_flags & MZ_ZIP_FLAG_COMPRESSED_DATA));
 


### PR DESCRIPTION
Issue #81

As MZ_DEFAULT_COMPRESSION is set as "-1", one of the bits is incorrectly
interpreted as the "MZ_ZIP_FLAG_COMPRESSED_DATA" flag before the check
for (flags < 0) intended to catch the MZ_DEFAULT_COMPRESION case.

This would then cause an assert() to be hit on any calls where the
uncomp_size is non-zero.

Moving the "Default" level check above any other flag checks should
solve this issue.